### PR TITLE
Add Git revision to page for version tracking

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,16 +36,16 @@ module.exports = function(grunt) {
                     sourceMap: true
                 },
                 files: {
-                    "public/dist/application.min.js": "<%= applicationJavaScriptFiles %>",
-                    "public/dist/templates.min.js": "public/dist/templates.js"
+                    "<%= minifiedApplicationJavaScriptFiles %>": "<%= applicationJavaScriptFiles %>",
+                    "<%= minifiedTemplates %>": "public/dist/templates.js"
                 }
             }
         },
         cssmin: {
             combine: {
                 files: {
-                    "public/dist/application.min.css": "<%= applicationCSSFiles %>",
-                    "public/dist/vendor.min.css": "<%= vendorCSSFiles %>"
+                    "<%= minifiedApplicationCSSFiles %>": "<%= applicationCSSFiles %>",
+                    "<%= minifiedVendorCSSFiles %>": "<%= vendorCSSFiles %>"
                 }
             }
         },
@@ -55,7 +55,7 @@ module.exports = function(grunt) {
                     stripBanners: true
                 },
                 files: {
-                    "public/dist/vendor.min.js": "<%= vendorJavaScriptFiles %>"
+                    "<%= minifiedVendorJavaScriptFiles %>": "<%= vendorJavaScriptFiles %>"
                 }
             }
         },
@@ -173,11 +173,25 @@ module.exports = function(grunt) {
     grunt.task.registerTask("loadConfig", "Task that loads the config into a grunt option.", function() {
         var init = require("./config/init")();
         var config = require("./config/config");
+        var gitRev = require("git-rev-sync");
 
         grunt.config.set("vendorJavaScriptFiles", config.assets.lib.js);
         grunt.config.set("vendorCSSFiles", config.assets.lib.css);
         grunt.config.set("applicationJavaScriptFiles", config.assets.js);
         grunt.config.set("applicationCSSFiles", config.assets.css);
+
+        // the minified asset names (with git version)
+        var version = gitRev.short();
+        grunt.config.set("minifiedVendorJavaScriptFiles",
+            "public/dist/vendor-" + version + ".min.js");
+        grunt.config.set("minifiedVendorCSSFiles",
+            "public/dist/vendor-" + version + ".min.css");
+        grunt.config.set("minifiedApplicationJavaScriptFiles",
+            "public/dist/application-" + version + ".min.js");
+        grunt.config.set("minifiedApplicationCSSFiles",
+            "public/dist/application-" + version + ".min.css");
+        grunt.config.set("minifiedTemplates",
+            "public/dist/templates-" + version + ".min.js");
     });
 
     grunt.registerTask("server", "Start the server", function() {

--- a/app/views/layout.server.view.html
+++ b/app/views/layout.server.view.html
@@ -10,6 +10,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
+    <!-- git revision: {{gitRevision}} -->
+
     <!--Application CSS Files-->
     {% for cssFile in cssFiles %}
     <link rel="stylesheet" href="{{cssFile}}">{% endfor %}

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,21 +1,25 @@
 "use strict";
 
+var gitRev = require("git-rev-sync");
+
+var version = gitRev.short();
+
 module.exports = {
     assets: {
         lib: {
             css: [
-                "public/dist/vendor.min.css"
+                "public/dist/vendor-" + version + ".min.css"
             ],
             js: [
-                "public/dist/vendor.min.js"
+                "public/dist/vendor-" + version + ".min.js"
             ]
         },
         css: [
-            "public/dist/application.min.css"
+            "public/dist/application-" + version + ".min.css"
         ],
         js: [
-            "public/dist/application.min.js",
-            "public/dist/templates.min.js"
+            "public/dist/application-" + version + ".min.js",
+            "public/dist/templates-" + version + ".min.js"
         ]
     }
 };

--- a/config/express.js
+++ b/config/express.js
@@ -9,7 +9,8 @@ var express = require("express"),
     passport = require("passport"),
     config = require("./config"),
     consolidate = require("consolidate"),
-    path = require("path");
+    path = require("path"),
+    gitRev = require("git-rev");
 
 module.exports = function(db) {
     // Initialize express app
@@ -23,6 +24,9 @@ module.exports = function(db) {
     // Setting application local variables
     app.locals.jsFiles = config.getJavaScriptAssets();
     app.locals.cssFiles = config.getCSSAssets();
+    gitRev.long(function(version) {
+        app.locals.gitRevision = version;
+    });
 
     // Passing the request url to environment locals
     app.use(function(req, res, next) {

--- a/config/express.js
+++ b/config/express.js
@@ -10,7 +10,7 @@ var express = require("express"),
     config = require("./config"),
     consolidate = require("consolidate"),
     path = require("path"),
-    gitRev = require("git-rev");
+    gitRev = require("git-rev-sync");
 
 module.exports = function(db) {
     // Initialize express app
@@ -24,9 +24,7 @@ module.exports = function(db) {
     // Setting application local variables
     app.locals.jsFiles = config.getJavaScriptAssets();
     app.locals.cssFiles = config.getCSSAssets();
-    gitRev.long(function(version) {
-        app.locals.gitRevision = version;
-    });
+    app.locals.gitRevision = gitRev.long();
 
     // Passing the request url to environment locals
     app.use(function(req, res, next) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "cookie-session": "~1.0.2",
         "debug": "~2.0.0",
         "express": "~4.8.5",
-        "git-rev": "~0.2.1",
+        "git-rev-sync": "~1.0.0",
         "glob": "~4.0.5",
         "helmet": "~0.4.0",
         "lodash": "~2.4.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "cookie-session": "~1.0.2",
         "debug": "~2.0.0",
         "express": "~4.8.5",
+        "git-rev": "~0.2.1",
         "glob": "~4.0.5",
         "helmet": "~0.4.0",
         "lodash": "~2.4.1",


### PR DESCRIPTION
In order to better track what version of the app is deployed, include the Git revision in the page.  Since it’s included in the `layout.server.view.html`, this will be available on all pages within the application.