### PR TITLE
Replace logger, npm start changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,14 @@ If no environment is specified, it will default to `development`.
 
 To start the application (in development mode), execute the following command:
 
-`$ NODE_ENV=development npm start`
+`$ npm start`
+
+This script will call `grunt` specifying the `development` environment. If
+you wish you specify an environment, use `grunt` directly and include the
+`NODE_ENV` environment variable. For example, to start the project in `test`
+environment, execute the following command:
+
+`$ NODE_ENV=test grunt`
 
 The current available environments include:
 
@@ -95,7 +102,7 @@ The current available environments include:
 In production mode the application is setup to use minified assets
 on the client side (along with template caching via Angular).
 [Grunt](http://gruntjs.com/) is used to do this via the grunt `build`
-task. To execute this task, run the following command:
+task. To execute this build task, run the following command:
 
 `$ npm run build`
 
@@ -103,6 +110,10 @@ To start the server in the `production` environment, execute the following
 command:
 
 `$ npm run production`
+
+This command does not use `grunt`, and therefore does not use `nodemon` to
+monitor for file system changes. This was done to allow a separate "production"
+process to monitor the state of the server.
 
 ### Configuration ###
 

--- a/app/lib/logger.js
+++ b/app/lib/logger.js
@@ -1,59 +1,15 @@
 "use strict";
 
-var debug = require("debug");
+var debugCaller = require("debug-caller"),
+    projectConfig = require("../../package.json");
 
-// enable the "meanjs-template" namespace by default
-debug.enable("meanjs-template*");
+// enable the app namespace by default
+debugCaller.debug.enable(projectConfig.name + "*");
 
-// returns the calling filename, but prepended with "meanjs-template:"
-function _getDecorator() {
-    // the code below screws up test output when a test fails,
-    // so in the test environment, set this to return a constant
-    // string rather than determining the decorator via stack trace.
-    if (process.env.NODE_ENV === "test") {
-        return "meanjs-template:test_environment";
-    }
-
-    try {
-        var err = new Error();
-        var callerfile;
-        var currentfile;
-
-        Error.prepareStackTrace = function(err, stack) {
-            return stack;
-        };
-
-        currentfile = err.stack.shift().getFileName();
-
-        while (err.stack.length) {
-            callerfile = err.stack.shift().getFileName();
-
-            if (currentfile !== callerfile) {
-                // trim the file to the file name itself (minus the .js)
-                callerfile = callerfile.slice(callerfile.lastIndexOf("/") + 1, callerfile.indexOf(".js"));
-                // prepend the project name
-                return "meanjs-template:" + callerfile;
-            }
-        }
-    } catch (err) {}
-    return undefined;
-}
-
-function logger() {
-    var decorator, log, error;
-
-    // get the filename which is used to decorate the debug module
-    decorator = _getDecorator();
-
-    // setup two debug'ers, one for console.log and one for console.error
-    log = debug(decorator);
-    error = debug(decorator);
-    error.log = console.error.bind(console);
-
-    // return the two under the log and error functions
-    return {
-        log: log,
-        error: error
-    };
-}
-module.exports = logger;
+module.exports = function() {
+    // set a depth of 2 to avoid using this file within debug statements
+    // (since this is just a passthrough for logging)
+    return debugCaller(projectConfig.name, {
+        depth: 2
+    });
+};

--- a/bower.json
+++ b/bower.json
@@ -8,5 +8,8 @@
         "angular-mocks": "1.4.x",
         "angular-ui-router": "0.2.x",
         "jquery": "~2.1.3"
+    },
+    "resolutions": {
+        "angular": "1.4.x"
     }
 }

--- a/config/express.js
+++ b/config/express.js
@@ -79,7 +79,7 @@ module.exports = function(db) {
     // use express' session
     app.use(session({
         name: "meanjs-template",
-        secret: "meanjs-template-super-secret-phrase"
+        secret: config.sessionSecret
     }));
 
     // use passport session

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "start": "grunt",
+        "start": "NODE_ENV=development grunt",
 
         "build": "grunt build",
         "production": "NODE_ENV=production node server.js",
@@ -25,7 +25,7 @@
         "compression": "~1.4.2",
         "consolidate": "~0.11.0",
         "cookie-session": "~1.1.0",
-        "debug": "~2.1.2",
+        "debug-caller": "~2.0.0",
         "express": "~4.12.2",
         "git-rev-sync": "~1.0.0",
         "glob": "~5.0.3",

--- a/public/application.js
+++ b/public/application.js
@@ -6,7 +6,7 @@ angular.module(ApplicationConfiguration.applicationModuleName,
 
 // Setting HTML5 Location Mode
 angular.module(ApplicationConfiguration.applicationModuleName).config(["$locationProvider",
-    function($locationProvider, localStorageServiceProvider) {
+    function($locationProvider) {
         $locationProvider.html5Mode(true);
     }
 ]);

--- a/test/client/e2e/app.js
+++ b/test/client/e2e/app.js
@@ -1,6 +1,6 @@
 "use strict";
 
-describe("meanjs-template App", function() {
+describe("The application", function() {
     var ROOT_URL_PREFIX;
 
     // TODO should we keep these in a configuration file?

--- a/test/server/app/lib/logger.test.js
+++ b/test/server/app/lib/logger.test.js
@@ -13,40 +13,10 @@ describe("The logger library", function() {
         expect(logger).toBeDefined();
     });
 
-    it("should return test decorator in test environment", function() {
-        var _getDecorator;
-
-        _getDecorator = logger.__get__("_getDecorator");
-
-        // normal test
-        expect(_getDecorator()).toEqual("meanjs-template:test_environment");
-    });
-
-    describe("_getDecorator non-test node env", function() {
-        var ENV, _getDecorator;
-
-        beforeEach(function() {
-            ENV = process.env.NODE_ENV;
-            process.env.NODE_ENV = "notTest";
-
-            _getDecorator = logger.__get__("_getDecorator");
-        });
-
-        it("should return the correct decorator for our test", function() {
-            // "real" test (which if it fails, will cause stack trace issues)
-            expect(_getDecorator()).toEqual("meanjs-template:logger.test");
-        });
-
-        afterEach(function() {
-            process.env.NODE_ENV = ENV;
-        });
-
-    });
-
     it("should return a log and error function for logger", function() {
         var myLogger;
 
-        myLogger = logger.__get__("logger")();
+        myLogger = logger();
 
         expect(myLogger.log).toBeDefined();
         expect(myLogger.error).toBeDefined();


### PR DESCRIPTION
To avoid generating the stack trace to find the namespace for our logger, use the `debug-caller` library which does the work for us.

Default the `npm start` script to use the development environment. This is to avoid having to type that in every time, since it’s pretty much the one environment used for that command.  Document the change in the readme.